### PR TITLE
Fix initialization for DuFort-Frankel

### DIFF
--- a/dufrank.c
+++ b/dufrank.c
@@ -13,7 +13,7 @@ update_solution_dufrank(
     Number r = alpha * dt / (dx * dx);
     Number q = 1 / (1+r);
 
-    // FTCS update algorithm
+    // DuFort-Frankel update algorithm
     #pragma omp parallel for
     for (int i = 1; i < n-1; i++)
         uk[i] = q * (1-r) * uk2[i] + q * r * (uk1[i+1] + uk1[i-1]);

--- a/heat.c
+++ b/heat.c
@@ -118,7 +118,10 @@ initialize(void)
         back2 = (Number*) malloc(Nx * sizeof(Number));
 
     // Initial condition
-    set_initial_condition(Nx, back1, dx, ic);
+    set_initial_condition(Nx, curr, dx, ic);
+    copy(Nx, back1, curr);
+    if (back2)
+        copy(Nx, back2, curr);
 }
 
 int finalize(int ti, Number maxt, Number change)

--- a/tools/run_matplotlib.sh
+++ b/tools/run_matplotlib.sh
@@ -13,7 +13,7 @@ p0=$(perl -e "print $lenx2-$lenp2")
 # Compute right bound of pipe's width
 p1=$(perl -e "print $lenx2+$lenp2")
 
-python -t << EOF 2>/dev/null
+python3 -t << EOF 2>/dev/null
 import matplotlib.pyplot as plt
 import sys, time
 x = []


### PR DESCRIPTION
* The DuFort-Frankel algorithm uses previous results from **2** prior timesteps. We were initializing only one of these. I have adjusted the initialization to initialize the second prior timestep when DuFort-Frankel is active.
* I also fixed a comment
* Adjusted matplotlib.sh tool to use python3.